### PR TITLE
Add superagent serializer

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,9 +1,9 @@
-var parse = require('./common');
+var common = require('./common');
+
+var parse = common.parse;
+var serialize = common.serialize;
 
 module.exports = function(request) {
-	request.parse['application/vnd.api+json'] = parseJsonApi;
+	request.parse['application/vnd.api+json'] = parse;
+	request.serialize['application/vnd.api+json'] = serialize;
 };
-
-function parseJsonApi(text) {
-	return parse(text);
-}

--- a/common.js
+++ b/common.js
@@ -1,11 +1,13 @@
 var _ = require('lodash');
 
-module.exports = function(text) {
+exports.parse = function(text) {
 	var response = JSON.parse(text);
 	if (!_.isUndefined(response.data))
 		response.data = parseResourceData(response, response.data);
 	return response;
 };
+
+exports.serialize = JSON.stringify;
 
 function parseResourceData(response, data) {
 	if (!data) {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,11 @@
-var parse = require('./common');
+var common = require('./common');
+
+var parse = common.parse;
+var serialize = common.serialize;
 
 module.exports = function(request) {
 	request.parse['application/vnd.api+json'] = parseJsonApi;
+	request.serialize['application/vnd.api+json'] = serialize;
 };
 
 function parseJsonApi(res, callback) {
@@ -18,4 +22,3 @@ function parseJsonApi(res, callback) {
 		}
 	});
 }
-


### PR DESCRIPTION
Right now, making any kind of request with a body (eg POST, PUT, PATCH) results in an error because there is no serializer, so instead of sending JSON as the body, it sends `"[Object object]"`. This PR uses superagent's built in serializer for `application/json` to properly send requests.