### PR TITLE
Changing lodash require to only use submodules

### DIFF
--- a/common.js
+++ b/common.js
@@ -1,8 +1,18 @@
-var _ = require('lodash');
+var _isUndefined = require('lodash/isUndefined');
+var _isArray = require('lodash/isArray');
+var _map = require('lodash/map');
+var _partial = require('lodash/partial');
+var _each = require('lodash/each');
+var _camelCase = require('lodash/camelCase');
+var _memoize = require('lodash/memoize');
+var _chain = require('lodash/chain');
+var _find = require('lodash/find');
+var _clone = require('lodash/clone');
+var _compact = require('lodash/compact');
 
 exports.parse = function(text) {
 	var response = JSON.parse(text);
-	if (!_.isUndefined(response.data))
+	if (!_isUndefined(response.data))
 		response.data = parseResourceData(response, response.data);
 	return response;
 };
@@ -12,36 +22,37 @@ exports.serialize = JSON.stringify;
 function parseResourceData(response, data) {
 	if (!data) {
 		return data;
-	} else if (_.isArray(data)) {
-		return _.map(data, _.partial(parseResourceDataObject, response));
+	} else if (_isArray(data)) {
+		return _map(data, _partial(parseResourceDataObject, response));
 	} else {
 		return parseResourceDataObject(response, data);
 	}
 }
 
 function parseResourceDataObject(response, data) {
-	var result = _.clone(data);
-	_.each(data.attributes, function(value, name) {
-		Object.defineProperty(result, _.camelCase(name), { value: value, enumerable: true });
+	var result = _clone(data);
+	_each(data.attributes, function(value, name) {
+		Object.defineProperty(result, _camelCase(name), { value: value, enumerable: true });
 	});
-	_.each(data.relationships, function(value, name) {
-		if (_.isArray(value.data)) {
-			Object.defineProperty(result, _.camelCase(name), {
-				get: _.memoize(function() {
-					return _(value.data).map(function(related) {
-						var resdata = _.find(response.included, function(included) {
+	_each(data.relationships, function(value, name) {
+		if (_isArray(value.data)) {
+			Object.defineProperty(result, _camelCase(name), {
+				get: _memoize(function() {
+					const related = _map(value.data, function(related) {
+						var resdata = _find(response.included, function(included) {
 							return included.id === related.id && included.type === related.type;
 						});
 						if(resdata)
 							return parseResourceDataObject(response, resdata);
-					}).compact().value();
+					});
+					return _compact(related);
 				}),
 				enumerable: true
 			});
 		} else if (value.data) {
-			Object.defineProperty(result, _.camelCase(name), {
-				get: _.memoize(function() {
-					var resdata = _.find(response.included, function(included) {
+			Object.defineProperty(result, _camelCase(name), {
+				get: _memoize(function() {
+					var resdata = _find(response.included, function(included) {
 						return included.id === value.data.id && included.type === value.data.type;
 					});
 					return resdata ? parseResourceDataObject(response, resdata)


### PR DESCRIPTION
- Instead of requiring the entire lodash library in the browser only require submodules.  (This supports bundlers to allow for the smallest possible build size)
-  You will want to accept PR (https://github.com/alex94puchades/superagent-jsonapify/pull/10) first it is used to test this code.